### PR TITLE
いまのなし

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ LINE側
 
 ## 制約
 
-* LINE側の[制約](https://developers.line.biz/ja/docs/messaging-api/user-consent/)により，LINE側のユーザ名は情報の取得に同意したユーザのみ取得可能です．情報の取得に同意していないユーザは，ユーザ名の代わりに一意のIDで表示されます．
-* LINEスタンプには対応していません．
+- LINEスタンプはLINE→Slackの一方向のみの対応です．
+- SlackのユーザアイコンはLINE側には反映されません．
 
 ## Dockerイメージ
 

--- a/SlackLineBridge/Controllers/WebhookController.cs
+++ b/SlackLineBridge/Controllers/WebhookController.cs
@@ -99,13 +99,19 @@ namespace SlackLineBridge.Controllers
                 return BadRequest();
             }
 
-            using (var reader = new StreamReader(Request.Body))
-            {
-                _lineRequestQueue.Enqueue((Request.Headers["X-Line-Signature"], await reader.ReadToEndAsync()));
+            using var reader = new StreamReader(Request.Body);
 
-                return Ok();
-            }
+            _lineRequestQueue.Enqueue((Request.Headers["X-Line-Signature"], await reader.ReadToEndAsync()));
+
+            return Ok();
         }
+
+        [HttpGet("/health")]
+        public OkResult Health()
+        {
+            return Ok();
+        }
+
 
         private IEnumerable<Models.Configurations.SlackLineBridge> GetBridges(SlackChannel channel)
         {

--- a/SlackLineBridge/Services/BackgroundAccessingService.cs
+++ b/SlackLineBridge/Services/BackgroundAccessingService.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SlackLineBridge.Services
+{
+    public class BackgroundAccessingService : BackgroundService
+    {
+        private readonly ILogger<BackgroundAccessingService> _logger;
+        private readonly IHttpClientFactory _clientFactory;
+
+        public BackgroundAccessingService(ILogger<BackgroundAccessingService> logger, IHttpClientFactory clientFactory)
+        {
+            _logger = logger;
+            _clientFactory = clientFactory;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _logger.LogDebug($"BackgroundAccessingService is starting.");
+
+            stoppingToken.Register(() => _logger.LogDebug($" BackgroundAccessing background task is stopping."));
+
+            var client = _clientFactory.CreateClient();
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    var response = await client.GetAsync("http://localhost/health");
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        _logger.LogWarning("BackgroundAccessing failed.");
+
+                    }
+                }
+                catch
+                {
+                    _logger.LogWarning("BackgroundAccessing failed.");
+                }
+
+                await Task.Delay(1000 * 60, stoppingToken);
+            }
+
+            _logger.LogDebug($"BackgroundAccessing background task is stopped.");
+        }
+    }
+}

--- a/SlackLineBridge/Services/BackgroundAccessingService.cs
+++ b/SlackLineBridge/Services/BackgroundAccessingService.cs
@@ -31,7 +31,7 @@ namespace SlackLineBridge.Services
             {
                 try
                 {
-                    var response = await client.GetAsync("http://localhost/health");
+                    var response = await client.PostAsync("http://localhost/line", new StringContent(""));
                     if (!response.IsSuccessStatusCode)
                     {
                         _logger.LogWarning("BackgroundAccessing failed.");

--- a/SlackLineBridge/Services/BackgroundAccessingService.cs
+++ b/SlackLineBridge/Services/BackgroundAccessingService.cs
@@ -32,15 +32,10 @@ namespace SlackLineBridge.Services
                 try
                 {
                     var response = await client.PostAsync("http://localhost/line", new StringContent(""));
-                    if (!response.IsSuccessStatusCode)
-                    {
-                        _logger.LogWarning("BackgroundAccessing failed.");
-
-                    }
                 }
                 catch
                 {
-                    _logger.LogWarning("BackgroundAccessing failed.");
+                    // ignore
                 }
 
                 await Task.Delay(1000 * 60, stoppingToken);

--- a/SlackLineBridge/Services/LineMessageProcessingService.cs
+++ b/SlackLineBridge/Services/LineMessageProcessingService.cs
@@ -163,7 +163,7 @@ namespace SlackLineBridge.Services
                     } };
             }
 
-            var result = await client.PostAsync(webhookUrl, new StringContent(JsonSerializer.Serialize(message), Encoding.UTF8, "application/json"));
+            var result = await client.PostAsync(webhookUrl, new StringContent(JsonSerializer.Serialize(new Dictionary<string, object>(message)), Encoding.UTF8, "application/json"));
             _logger.LogInformation($"Post to Slack: {result.StatusCode} {await result.Content.ReadAsStringAsync()}");
         }
 

--- a/SlackLineBridge/Services/LineMessageProcessingService.cs
+++ b/SlackLineBridge/Services/LineMessageProcessingService.cs
@@ -94,7 +94,9 @@ namespace SlackLineBridge.Services
                                             var result = await client.GetAsync($"profile/{userId}");
                                             if (result.IsSuccessStatusCode)
                                             {
-                                                var profile = await JsonSerializer.DeserializeAsync<JsonElement>(await result.Content.ReadAsStreamAsync());
+                                                var profileJson = await result.Content.ReadAsStreamAsync();
+                                                _logger.LogInformation($"get profile: {profileJson}");
+                                                var profile = await JsonSerializer.DeserializeAsync<JsonElement>(profileJson);
                                                 userName = profile.GetProperty("displayName").GetString();
                                                 if (profile.TryGetProperty("pictureUrl", out var picture))
                                                 {

--- a/SlackLineBridge/Services/LineMessageProcessingService.cs
+++ b/SlackLineBridge/Services/LineMessageProcessingService.cs
@@ -179,7 +179,8 @@ namespace SlackLineBridge.Services
                 {
                     channel = channelId,
                     username = userName,
-                    icon_emoji = !string.IsNullOrEmpty(pictureUrl) ? pictureUrl : ":line:",
+                    icon_emoji = string.IsNullOrEmpty(pictureUrl) ? ":line:" : "",
+                    icon_url = string.IsNullOrEmpty(pictureUrl) ? "" : pictureUrl,
                     text
                 };
             }
@@ -189,7 +190,8 @@ namespace SlackLineBridge.Services
                 {
                     channel = channelId,
                     username = userName,
-                    icon_emoji = !string.IsNullOrEmpty(pictureUrl) ? pictureUrl : ":line:",
+                    icon_emoji = string.IsNullOrEmpty(pictureUrl) ? ":line:" : "",
+                    icon_url = string.IsNullOrEmpty(pictureUrl) ? "" : pictureUrl,
                     text,
                     blocks = new[]{new
                     {

--- a/SlackLineBridge/Services/LineMessageProcessingService.cs
+++ b/SlackLineBridge/Services/LineMessageProcessingService.cs
@@ -151,7 +151,7 @@ namespace SlackLineBridge.Services
                 await Task.Delay(1000, stoppingToken);
             }
 
-            _logger.LogDebug($"LineMessageProcessing background task is stopping.");
+            _logger.LogDebug($"LineMessageProcessing background task is stopped.");
         }
 
         private async Task SendToSlack(string webhookUrl, string channelId, string userName, string text)

--- a/SlackLineBridge/Services/LineMessageProcessingService.cs
+++ b/SlackLineBridge/Services/LineMessageProcessingService.cs
@@ -141,7 +141,7 @@ namespace SlackLineBridge.Services
                                             continue;
                                         }
 
-                                        await SendToSlack(slackChannel.WebhookUrl, slackChannel.ChannelId, pictureUrl, userName, text, stickerUrl);
+                                        await SendToSlack(_logger, slackChannel.WebhookUrl, slackChannel.ChannelId, pictureUrl, userName, text, stickerUrl);
                                     }
                                 }
                                 break;
@@ -166,7 +166,7 @@ namespace SlackLineBridge.Services
             _logger.LogDebug($"LineMessageProcessing background task is stopped.");
         }
 
-        private async Task SendToSlack(string webhookUrl, string channelId, string pictureUrl, string userName, string text, string stickerUrl)
+        private async Task SendToSlack(ILogger logger, string webhookUrl, string channelId, string pictureUrl, string userName, string text, string stickerUrl)
         {
             var client = _clientFactory.CreateClient();
 
@@ -198,7 +198,8 @@ namespace SlackLineBridge.Services
                 };
             }
 
-            await client.PostAsync(webhookUrl, new StringContent(JsonSerializer.Serialize(message), Encoding.UTF8, "application/json"));
+            var result = await client.PostAsync(webhookUrl, new StringContent(JsonSerializer.Serialize(message), Encoding.UTF8, "application/json"));
+            logger.LogInformation($"Post to Slack: {result.StatusCode} {await result.Content.ReadAsStringAsync()}");
         }
 
         private LineChannel GetLineChannel(JsonElement e)

--- a/SlackLineBridge/Services/LineMessageProcessingService.cs
+++ b/SlackLineBridge/Services/LineMessageProcessingService.cs
@@ -189,12 +189,12 @@ namespace SlackLineBridge.Services
                     username = userName,
                     icon_emoji = !string.IsNullOrEmpty(pictureUrl) ? pictureUrl : ":line:",
                     text,
-                    blocks = new
+                    blocks = new[]{new
                     {
                         type = "image",
                         image_url = stickerUrl,
                         alt_text = "sticker"
-                    }
+                    }}
                 };
             }
 

--- a/SlackLineBridge/Services/LineMessageProcessingService.cs
+++ b/SlackLineBridge/Services/LineMessageProcessingService.cs
@@ -95,8 +95,8 @@ namespace SlackLineBridge.Services
                                             if (result.IsSuccessStatusCode)
                                             {
                                                 var profileJson = await result.Content.ReadAsStreamAsync();
-                                                _logger.LogInformation($"get profile: {profileJson}");
                                                 var profile = await JsonSerializer.DeserializeAsync<JsonElement>(profileJson);
+                                                _logger.LogInformation($"get profile: {profile}");
                                                 userName = profile.GetProperty("displayName").GetString();
                                                 if (profile.TryGetProperty("pictureUrl", out var picture))
                                                 {

--- a/SlackLineBridge/Startup.cs
+++ b/SlackLineBridge/Startup.cs
@@ -58,6 +58,7 @@ namespace SlackLineBridge
             services.AddSingleton<ConcurrentQueue<(string signature, string body)>>(); //lineRequestQueue
             services.AddSingleton(Configuration["lineChannelSecret"]);
             services.AddHostedService<LineMessageProcessingService>();
+            services.AddHostedService<BackgroundAccessingService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
- しばらくアイドルだとLINEからのリクエストを捌くのが間に合わないのを修正 (#5)
- LINEスタンプ（LINE→Slack）に対応
- LINEのユーザアイコン（LINE→Slack）に対応
- LINEのBOTアカウントを友達登録していないユーザのプロフィール情報の取得に対応