### PR TITLE
Use flex message when send the message to LINE

### DIFF
--- a/SlackLineBridge/Controllers/WebhookController.cs
+++ b/SlackLineBridge/Controllers/WebhookController.cs
@@ -81,33 +81,35 @@ namespace SlackLineBridge.Controllers
                         {
                             type = "flex",
                             altText = $"{data.user_name}\r\n「{data.text}」",
-                            contents = new {
+                            contents = new
+                            {
                                 type = "bubble",
                                 size = "kilo",
-                                body = new {
-                                    type="box",
-                                    layout="vertical",
-                                    contents = new dynamic[] 
+                                body = new
+                                {
+                                    type = "box",
+                                    layout = "vertical",
+                                    contents = new dynamic[]
                                     {
-                                        new {
+                                        new
+                                        {
                                             type = "text",
-                                            text=$"{data.user_name}",
-                                            weight="bold",
-                                            wrap=true,
-                                            size="xs"
-                                            
+                                            text = data.user_name,
+                                            weight = "bold",
+                                            wrap = true,
+                                            size = "xs"
                                         },
                                         new
                                         {
-                                            type="separator",
-                                            margin="sm"
+                                            type = "separator",
+                                            margin = "sm"
                                         },
                                         new
                                         {
-                                            type="text",
-                                            text=$"{data.text}",
-                                            wrap=true,
-                                            margin="sm"
+                                            type = "text",
+                                            text = data.text,
+                                            wrap = true,
+                                            margin = "sm"
                                         }
                                     }
                                 }

--- a/SlackLineBridge/Controllers/WebhookController.cs
+++ b/SlackLineBridge/Controllers/WebhookController.cs
@@ -79,8 +79,39 @@ namespace SlackLineBridge.Controllers
                     {
                         new
                         {
-                            type = "text",
-                            text = $"{data.user_name}\r\n「{data.text}」"
+                            type = "flex",
+                            altText = $"{data.user_name}\r\n「{data.text}」",
+                            contents = new {
+                                type = "bubble",
+                                size = "kilo",
+                                body = new {
+                                    type="box",
+                                    layout="vertical",
+                                    contents = new dynamic[] 
+                                    {
+                                        new {
+                                            type = "text",
+                                            text=$"{data.user_name}",
+                                            weight="bold",
+                                            wrap=true,
+                                            size="xs"
+                                            
+                                        },
+                                        new
+                                        {
+                                            type="separator",
+                                            margin="sm"
+                                        },
+                                        new
+                                        {
+                                            type="text",
+                                            text=$"{data.text}",
+                                            wrap=true,
+                                            margin="sm"
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 };


### PR DESCRIPTION
Slackから送った人の名前が見辛いので、LINEにメッセージを送るときにflex messageを使うようにする。
![image](https://user-images.githubusercontent.com/3395369/93693892-a6044d80-fb40-11ea-9453-112a2aeea633.png)


[flex message simulator](https://developers.line.biz/flex-simulator/)でtestできるflex message のjson例
```json
{
  "type": "bubble",
  "size": "kilo",
  "body": {
    "type": "box",
    "layout": "vertical",
    "contents": [
      {
        "type": "text",
        "text": "test_name",
        "weight": "bold",
        "wrap": true,
        "size": "xs"
      },
      {
        "type": "separator",
        "margin": "sm"
      },
      {
        "type": "text",
        "text": "hogehoge",
        "wrap": true,
        "margin": "sm"
      }
    ],
    "spacing": "none"
  }
}
```